### PR TITLE
Use explicit version for rvi-vp-kraken2ref

### DIFF
--- a/conf/containers.config
+++ b/conf/containers.config
@@ -50,7 +50,7 @@ process {
         }
 
         withLabel: kraken2ref {
-            container = "quay.io/gsu-pipelines/rvi-vp-kraken2ref"
+            container = "quay.io/gsu-pipelines/rvi-vp-kraken2ref:v2.1.0"
         }
 
         withLabel: qc {


### PR DESCRIPTION
With the change all repos in `containers.config -> use_registry_containers` have explicit versions.